### PR TITLE
TPC space-charge: fix deletion of non-allocated pointers

### DIFF
--- a/GPU/TPCSpaceChargeBase/AliTPC3DCylindricalInterpolator.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPC3DCylindricalInterpolator.cxx
@@ -30,6 +30,10 @@ ClassImp(AliTPC3DCylindricalInterpolator)
   /// constructor
   ///
   AliTPC3DCylindricalInterpolator::AliTPC3DCylindricalInterpolator()
+  : fValue(nullptr),
+    fRList(nullptr),
+    fPhiList(nullptr),
+    fZList(nullptr)
 {
   fOrder = 1;
   fIsAllocatingLookUp = kFALSE;
@@ -40,12 +44,10 @@ ClassImp(AliTPC3DCylindricalInterpolator)
 ///
 AliTPC3DCylindricalInterpolator::~AliTPC3DCylindricalInterpolator()
 {
-  if (fIsAllocatingLookUp) {
-    delete fValue;
-    delete fRList;
-    delete fPhiList;
-    delete fZList;
-  }
+  delete fValue;
+  delete fRList;
+  delete fPhiList;
+  delete fZList;
   if (fIsInitCubic) {
     delete fSecondDerZ;
   }

--- a/GPU/TPCSpaceChargeBase/AliTPC3DCylindricalInterpolatorIrregular.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPC3DCylindricalInterpolatorIrregular.cxx
@@ -45,6 +45,12 @@ ClassImp(AliTPC3DCylindricalInterpolatorIrregular)
   /// \param type
   AliTPC3DCylindricalInterpolatorIrregular::AliTPC3DCylindricalInterpolatorIrregular(
     Int_t nRRow, Int_t nZColumn, Int_t nPhiSlice, Int_t rStep, Int_t zStep, Int_t phiStep, Int_t type)
+  : fValue(nullptr),
+    fRList(nullptr),
+    fPhiList(nullptr),
+    fZList(nullptr),
+    fKDTreeIrregularPoints(nullptr),
+    fKDTreeIrregularRoot(nullptr)
 {
   fOrder = 1;
   fIsAllocatingLookUp = kFALSE;
@@ -72,6 +78,14 @@ ClassImp(AliTPC3DCylindricalInterpolatorIrregular)
 /// constructor
 ///
 AliTPC3DCylindricalInterpolatorIrregular::AliTPC3DCylindricalInterpolatorIrregular()
+  : fRBFWeightLookUp(nullptr),
+    fRBFWeight(nullptr),
+    fValue(nullptr),
+    fRList(nullptr),
+    fPhiList(nullptr),
+    fZList(nullptr),
+    fKDTreeIrregularPoints(nullptr),
+    fKDTreeIrregularRoot(nullptr)
 {
   fOrder = 1;
   fIsAllocatingLookUp = kFALSE;
@@ -84,15 +98,14 @@ AliTPC3DCylindricalInterpolatorIrregular::AliTPC3DCylindricalInterpolatorIrregul
 AliTPC3DCylindricalInterpolatorIrregular::~AliTPC3DCylindricalInterpolatorIrregular()
 {
 
-  if (fIsAllocatingLookUp) {
-    delete fValue;
-    delete fRList;
-    delete fPhiList;
-    delete fZList;
-  }
+  delete fValue;
+  delete fRList;
+  delete fPhiList;
+  delete fZList;
 
   if (fKDTreeIrregularPoints) {
     delete[] fKDTreeIrregularPoints;
+    delete fKDTreeIrregularRoot;
   }
   delete[] fRBFWeightLookUp;
   delete[] fRBFWeight;

--- a/GPU/TPCSpaceChargeBase/AliTPCLookUpTable3DInterpolatorD.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCLookUpTable3DInterpolatorD.cxx
@@ -28,6 +28,12 @@ ClassImp(AliTPCLookUpTable3DInterpolatorD)
 
   /// constructor
   AliTPCLookUpTable3DInterpolatorD::AliTPCLookUpTable3DInterpolatorD()
+  : fLookUpR(nullptr),
+    fLookUpPhi(nullptr),
+    fLookUpZ(nullptr),
+    fInterpolatorR(nullptr),
+    fInterpolatorPhi(nullptr),
+    fInterpolatorZ(nullptr)
 {
   fOrder = 1;
   fIsAllocatingLookUp = kFALSE;
@@ -143,21 +149,6 @@ AliTPCLookUpTable3DInterpolatorD::AliTPCLookUpTable3DInterpolatorD(
 /// destructor
 AliTPCLookUpTable3DInterpolatorD::~AliTPCLookUpTable3DInterpolatorD()
 {
-  if (fIsAllocatingLookUp) {
-    for (Int_t m = 0; m < fNPhi; m++) {
-      delete fLookUpR[m];
-      delete fLookUpPhi[m];
-      delete fLookUpZ[m];
-    }
-    delete fLookUpR;
-    delete fLookUpPhi;
-    delete fLookUpZ;
-
-    delete fRList;
-    delete fPhiList;
-    delete fZList;
-  }
-
   delete fInterpolatorR;
   delete fInterpolatorZ;
   delete fInterpolatorPhi;

--- a/GPU/TPCSpaceChargeBase/AliTPCLookUpTable3DInterpolatorD.h
+++ b/GPU/TPCSpaceChargeBase/AliTPCLookUpTable3DInterpolatorD.h
@@ -66,9 +66,9 @@ class AliTPCLookUpTable3DInterpolatorD
   AliTPC3DCylindricalInterpolator* fInterpolatorPhi; ///->Interpolator for Phi component
   AliTPC3DCylindricalInterpolator* fInterpolatorZ;   ///-> Interpolator for Z component
 
-  Double_t* fRList;   //[fNR]List of R coordinate (regular grid)
-  Double_t* fPhiList; //[fNPhi]List of Phi coordinate (regular grid)
-  Double_t* fZList;   //[fNZ]List of Z coordinate (regular grid)
+  Double_t* fRList;   //[fNR] List of R coordinate (regular grid)
+  Double_t* fPhiList; //[fNPhi] List of Phi coordinate (regular grid)
+  Double_t* fZList;   //[fNZ] List of Z coordinate (regular grid)
 
   Bool_t fIsAllocatingLookUp; ///< flag for initialization of cubic spline
 

--- a/GPU/TPCSpaceChargeBase/AliTPCLookUpTable3DInterpolatorIrregularD.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCLookUpTable3DInterpolatorIrregularD.cxx
@@ -27,6 +27,15 @@ ClassImp(AliTPCLookUpTable3DInterpolatorIrregularD)
 
   /// constructor
   AliTPCLookUpTable3DInterpolatorIrregularD::AliTPCLookUpTable3DInterpolatorIrregularD()
+  : fMatricesRValue(nullptr),
+    fMatricesPhiValue(nullptr),
+    fMatricesZValue(nullptr),
+    fMatricesRPoint(nullptr),
+    fMatricesPhiPoint(nullptr),
+    fMatricesZPoint(nullptr),
+    fInterpolatorR(nullptr),
+    fInterpolatorPhi(nullptr),
+    fInterpolatorZ(nullptr)
 {
   fOrder = 1;
   fIsAllocatingLookUp = kFALSE;
@@ -92,23 +101,6 @@ AliTPCLookUpTable3DInterpolatorIrregularD::AliTPCLookUpTable3DInterpolatorIrregu
 /// destructor
 AliTPCLookUpTable3DInterpolatorIrregularD::~AliTPCLookUpTable3DInterpolatorIrregularD()
 {
-
-  if (fIsAllocatingLookUp) {
-    for (Int_t m = 0; m < fNPhi; m++) {
-      delete fMatricesRValue[m];
-      delete fMatricesPhiValue[m];
-      delete fMatricesZValue[m];
-      delete fMatricesRPoint[m];
-      delete fMatricesPhiPoint[m];
-      delete fMatricesZPoint[m];
-    }
-    delete fMatricesRValue;
-    delete fMatricesPhiValue;
-    delete fMatricesZValue;
-    delete fMatricesRPoint;
-    delete fMatricesPhiPoint;
-    delete fMatricesZPoint;
-  }
   delete fInterpolatorR;
   delete fInterpolatorZ;
   delete fInterpolatorPhi;

--- a/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
@@ -45,7 +45,9 @@ Double_t AliTPCPoissonSolver::fgConvergenceError = 1e-3;
 /// constructor
 ///
 AliTPCPoissonSolver::AliTPCPoissonSolver()
-  : TNamed("poisson solver", "solver"), fStrategy(kRelaxation)
+  : TNamed("poisson solver", "solver"),
+    fStrategy(kRelaxation),
+    fExactSolution(nullptr)
 {
 
   // default strategy
@@ -54,15 +56,14 @@ AliTPCPoissonSolver::AliTPCPoissonSolver()
   fErrorConvergenceNorm2 = new TVectorD(fMgParameters.nMGCycle);
   fErrorConvergenceNormInf = new TVectorD(fMgParameters.nMGCycle);
   fError = new TVectorD(fMgParameters.nMGCycle);
-
-  //fExactSolution == NULL;
 }
 
 /// Constructor
 /// \param name name of the object
 /// \param title title of the object
 AliTPCPoissonSolver::AliTPCPoissonSolver(const char* name, const char* title)
-  : TNamed(name, title)
+  : TNamed(name, title),
+    fExactSolution(nullptr)
 {
   fExactPresent = kFALSE;
   fErrorConvergenceNorm2 = new TVectorD(fMgParameters.nMGCycle);
@@ -75,6 +76,7 @@ AliTPCPoissonSolver::AliTPCPoissonSolver(const char* name, const char* title)
 AliTPCPoissonSolver::~AliTPCPoissonSolver()
 {
   /// virtual destructor
+  delete[] fExactSolution;
   delete fErrorConvergenceNorm2;
   delete fErrorConvergenceNormInf;
   delete fError;

--- a/GPU/TPCSpaceChargeBase/CMakeLists.txt
+++ b/GPU/TPCSpaceChargeBase/CMakeLists.txt
@@ -64,13 +64,13 @@ if(${ALIGPU_BUILD_TYPE} STREQUAL "O2")
   O2_GENERATE_LIBRARY()
   install(FILES ${HDRS} DESTINATION include/GPU)
 
-#  set(TEST_SRCS
-#    ctest/testTPCSpaceChargeBase.cxx
-#  )
+ set(TEST_SRCS
+   ctest/testTPCSpaceChargeBase.cxx
+ )
 
-#  O2_GENERATE_TESTS(
-#    MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-#    BUCKET_NAME ${BUCKET_NAME}
-#    TEST_SRCS ${TEST_SRCS}
-# )
+ O2_GENERATE_TESTS(
+   MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+   BUCKET_NAME ${BUCKET_NAME}
+   TEST_SRCS ${TEST_SRCS}
+)
 endif()


### PR DESCRIPTION
1) Added default initializers for member pointers

2) Some of the member pointers in some of the classes are supposed to be owned externally (e.g. by another class).  This together with missing default initializers for member pointers caused seg faults when calling the destructors. This should be fixed with this commit.

Result of (previously failing) ctest that revealed the problems:
Test project /Applications/alicesw/sw/BUILD/O2-latest-o2-dev/O2/Detectors/TPC/simulation/TPCSpaceChargeBase
    Start 1: test__testTPCSpaceChargeBase
1/1 Test #1: test__testTPCSpaceChargeBase .....   Passed    2.21 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   2.23 sec