### PR TITLE
Bugfix in TPCFastTransform with reduced metadata

### DIFF
--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
@@ -512,9 +512,18 @@ void TPCFastSpaceChargeCorrection::finishConstruction()
     mSectorDataSizeBytes[is] = 0;
     for (int32_t j = 0; j < mGeo.getNumberOfRows(); j++) {
       RowInfo& row = getRowInfo(j);
-      SplineType& spline = mConstructionScenarios[row.splineScenarioID];
       row.dataOffsetBytes[is] = mSectorDataSizeBytes[is];
-      mSectorDataSizeBytes[is] += spline.getSizeOfParameters();
+      const SplineType& spline = mConstructionScenarios[row.splineScenarioID];
+      if (is == 0) {
+        const SplineTypeXYZ& splineXYZ = reinterpret_cast<const SplineTypeXYZ&>(spline);
+        mSectorDataSizeBytes[is] += splineXYZ.getSizeOfParameters();
+      } else if (is == 1) {
+        const SplineTypeInvX& splineInvX = reinterpret_cast<const SplineTypeInvX&>(spline);
+        mSectorDataSizeBytes[is] += splineInvX.getSizeOfParameters();
+      } else if (is == 2) {
+        const SplineTypeInvYZ& splineInvYZ = reinterpret_cast<const SplineTypeInvYZ&>(spline);
+        mSectorDataSizeBytes[is] += splineInvYZ.getSizeOfParameters();
+      }
     }
     bufferSize += mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
   }
@@ -556,24 +565,23 @@ GPUd() void TPCFastSpaceChargeCorrection::setNoCorrection()
   } // row
 
   for (int32_t sector = 0; sector < mGeo.getNumberOfSectors(); sector++) {
-
     for (int32_t row = 0; row < mGeo.getNumberOfRows(); row++) {
-      const SplineType& spline = getSplineForRow(row);
       for (int32_t is = 0; is < 3; is++) {
         float* data = getCorrectionData(sector, row, is);
-        int32_t nPar = spline.getNumberOfParameters();
-        if (is == 1) {
-          nPar = nPar / 3;
-        }
-        if (is == 2) {
-          nPar = nPar * 2 / 3;
+        int32_t nPar = 0;
+        if (is == 0) {
+          nPar = getSplineForRow(row).getNumberOfParameters();
+        } else if (is == 1) {
+          nPar = getSplineInvXforRow(row).getNumberOfParameters();
+        } else if (is == 2) {
+          nPar = getSplineInvYZforRow(row).getNumberOfParameters();
         }
         for (int32_t i = 0; i < nPar; i++) {
           data[i] = 0.f;
         }
       }
     } // row
-  } // sector
+  }   // sector
 }
 
 void TPCFastSpaceChargeCorrection::constructWithNoCorrection(const TPCFastTransformGeo& geo)

--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
@@ -147,9 +147,8 @@ void TPCFastSpaceChargeCorrection::setActualBufferAddress(char* actualFlatBuffer
     }
     size_t bufferSize = scBufferOffset + scBufferSize;
     for (int32_t is = 0; is < 3; is++) {
-      size_t correctionDataOffset = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
-      mCorrectionData[is] = reinterpret_cast<char*>(mFlatBufferPtr + correctionDataOffset);
-      bufferSize = correctionDataOffset + mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
+      mCorrectionData[is] = reinterpret_cast<char*>(mFlatBufferPtr + bufferSize);
+      bufferSize += mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
     }
     return;
   }
@@ -256,7 +255,7 @@ void TPCFastSpaceChargeCorrection::setActualBufferAddress(char* actualFlatBuffer
 
   for (int32_t is = 0; is < 3; is++) {
     size_t oldCorrectionDataOffset = alignSize(oldBufferSize, SplineType::getParameterAlignmentBytes());
-    size_t correctionDataOffset = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
+    size_t correctionDataOffset = bufferSize;
     mCorrectionData[is] = reinterpret_cast<char*>(mFlatBufferPtr + correctionDataOffset);
     memmove(mCorrectionData[is], mFlatBufferPtr + oldCorrectionDataOffset, mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors());
     oldBufferSize = oldCorrectionDataOffset + mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
@@ -509,16 +508,15 @@ void TPCFastSpaceChargeCorrection::finishConstruction()
   size_t bufferSize = scBufferOffsets[0] + scBufferSize;
   size_t correctionDataOffset[3];
   for (int32_t is = 0; is < 3; is++) {
-    correctionDataOffset[is] = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
+    correctionDataOffset[is] = bufferSize;
     mSectorDataSizeBytes[is] = 0;
     for (int32_t j = 0; j < mGeo.getNumberOfRows(); j++) {
       RowInfo& row = getRowInfo(j);
       SplineType& spline = mConstructionScenarios[row.splineScenarioID];
-      row.dataOffsetBytes[is] = alignSize(mSectorDataSizeBytes[is], SplineType::getParameterAlignmentBytes());
-      mSectorDataSizeBytes[is] = row.dataOffsetBytes[is] + spline.getSizeOfParameters();
+      row.dataOffsetBytes[is] = mSectorDataSizeBytes[is];
+      mSectorDataSizeBytes[is] += spline.getSizeOfParameters();
     }
-    mSectorDataSizeBytes[is] = alignSize(mSectorDataSizeBytes[is], SplineType::getParameterAlignmentBytes());
-    bufferSize = correctionDataOffset[is] + mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
+    bufferSize += mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
   }
 
   FlatObject::finishConstruction(bufferSize);

--- a/GPU/TPCFastTransformation/TPCFastTransformPOD.cxx
+++ b/GPU/TPCFastTransformation/TPCFastTransformPOD.cxx
@@ -169,40 +169,27 @@ TPCFastTransformPOD* TPCFastTransformPOD::create(char* buff, size_t buffSize, co
     nextDynOffs = alignOffset(nextDynOffs + spline.getFlatBufferSize());
   }
 
-  // copy spline data w/o memory alignment gaps between the sectors
+  // copy spline data
   for (int is = 0; is < 3; is++) {
     float* data = reinterpret_cast<float*>(buff + nextDynOffs);
     LOGP(debug, "splinID={} start offset {} -> {}", is, nextDynOffs, (void*)data);
 
     // metadata
-    size_t sectorDataSizeFloats = 0;
-    size_t sectorDataSizeBytes = 0;
-    for (int row = 0; row < NROWS; row++) {
-      podMap.getRowInfo(row).dataOffsetBytes[is] = sectorDataSizeBytes;
-      const auto& spline = origCorr.getSplineForRow(row);
-      int nPar = spline.getNumberOfParameters();
-      if (is == 1) {
-        nPar = nPar / 3;
-      }
-      if (is == 2) {
-        nPar = nPar * 2 / 3;
-      }
-      sectorDataSizeFloats += nPar;
-      sectorDataSizeBytes += nPar * sizeof(float);
-    }
+    size_t sectorDataSizeBytes = origCorr.mSectorDataSizeBytes[is];
 
     for (int sector = 0; sector < origCorr.mGeo.getNumberOfSectors(); sector++) {
-      podMap.mSplineDataOffsets[sector][is] = nextDynOffs;
-      if (buffSize < nextDynOffs + sectorDataSizeBytes) {
-        throw std::runtime_error(fmt::format("attempt to copy {} bytes of data for spline{} of sector{} to {}, overflowing the buffer of size {}", sectorDataSizeBytes, is, sector, nextDynOffs, buffSize));
-      }
-      const float* dataOr = origCorr.getCorrectionData(sector, 0, is);
-      std::memcpy(data, dataOr, sectorDataSizeBytes);
-      data += sectorDataSizeFloats;
-      nextDynOffs += sectorDataSizeBytes;
+      podMap.mSplineDataOffsets[sector][is] = sectorDataSizeBytes * sector;
     }
+    if (buffSize < nextDynOffs + sectorDataSizeBytes * origCorr.mGeo.getNumberOfSectors()) {
+      throw std::runtime_error(fmt::format("attempt to copy {} bytes of data for spline{} to {}, overflowing the buffer of size {}", sectorDataSizeBytes, is, nextDynOffs, buffSize));
+    }
+    const char* dataOr = origCorr.mCorrectionData[is];
+    size_t dataSize = origCorr.mGeo.getNumberOfSectors() * sectorDataSizeBytes;
+    std::memcpy(data, dataOr, dataSize);
+    nextDynOffs += dataSize;
   }
-  podMap.mTotalSize = alignOffset(nextDynOffs);
+
+  podMap.mTotalSize = nextDynOffs;
   if (buffSize != podMap.mTotalSize) {
     throw std::runtime_error(fmt::format("Estimated buffer size {} differs from filled one {}", buffSize, podMap.mTotalSize));
   }

--- a/GPU/TPCFastTransformation/TPCFastTransformPOD.cxx
+++ b/GPU/TPCFastTransformation/TPCFastTransformPOD.cxx
@@ -31,7 +31,7 @@ TPCFastTransformPOD* TPCFastTransformPOD::create(aligned_unique_buffer_ptr<TPCFa
 {
   size_t size = estimateSize(src);
   destVector.alloc(size); // allocate exact size
-  LOGP(debug, "OrigCorrSize:{} SelfSize: {} Estimated POS size: {}", src.getCorrection().getFlatBufferSize(), sizeof(TPCFastTransformPOD), size);
+  LOGP(debug, "OrigCorrSize:{} SelfSize: {} Estimated POD size: {}", src.getCorrection().getFlatBufferSize(), sizeof(TPCFastTransformPOD), size);
   auto res = create(destVector.getraw(), size, src);
   res->setTimeStamp(src.getTimeStamp());
   res->setVDrift(src.getVDrift());
@@ -48,7 +48,7 @@ TPCFastTransformPOD* TPCFastTransformPOD::create(aligned_unique_buffer_ptr<TPCFa
   // create filling only part corresponding to TPCFastSpaceChargeCorrection. Data members coming from TPCFastTransform (e.g. VDrift, T0..) are not set
   size_t size = estimateSize(origCorr);
   destVector.alloc(size);
-  LOGP(debug, "OrigCorrSize:{} SelfSize: {} Estimated POS size: {}", origCorr.getFlatBufferSize(), sizeof(TPCFastTransformPOD), size);
+  LOGP(debug, "OrigCorrSize:{} SelfSize: {} Estimated POD size: {}", origCorr.getFlatBufferSize(), sizeof(TPCFastTransformPOD), size);
   return create(destVector.getraw(), size, origCorr);
 }
 
@@ -67,19 +67,7 @@ size_t TPCFastTransformPOD::estimateSize(const TPCFastSpaceChargeCorrection& ori
   }
   // space for splines data
   for (int is = 0; is < 3; is++) {
-    for (int sector = 0; sector < origCorr.mGeo.getNumberOfSectors(); sector++) {
-      for (int row = 0; row < NROWS; row++) {
-        const auto& spline = origCorr.getSplineForRow(row);
-        int nPar = spline.getNumberOfParameters();
-        if (is == 1) {
-          nPar = nPar / 3;
-        }
-        if (is == 2) {
-          nPar = nPar * 2 / 3;
-        }
-        nextDynOffs += nPar * sizeof(float);
-      }
-    }
+    nextDynOffs += origCorr.mSectorDataSizeBytes[is] * TPCFastTransformGeo::getNumberOfSectors();
   }
   nextDynOffs = alignOffset(nextDynOffs);
   return nextDynOffs;
@@ -177,18 +165,18 @@ TPCFastTransformPOD* TPCFastTransformPOD::create(char* buff, size_t buffSize, co
     // metadata
     size_t sectorDataSizeBytes = origCorr.mSectorDataSizeBytes[is];
 
-    for (int sector = 0; sector < origCorr.mGeo.getNumberOfSectors(); sector++) {
-      podMap.mSplineDataOffsets[sector][is] = sectorDataSizeBytes * sector;
+    for (int sector = 0; sector < TPCFastTransformGeo::getNumberOfSectors(); sector++) {
+      podMap.mSplineDataOffsets[sector][is] = nextDynOffs + sectorDataSizeBytes * sector;
     }
-    if (buffSize < nextDynOffs + sectorDataSizeBytes * origCorr.mGeo.getNumberOfSectors()) {
+    size_t dataSize = TPCFastTransformGeo::getNumberOfSectors() * sectorDataSizeBytes;
+    if (buffSize < nextDynOffs + dataSize) {
       throw std::runtime_error(fmt::format("attempt to copy {} bytes of data for spline{} to {}, overflowing the buffer of size {}", sectorDataSizeBytes, is, nextDynOffs, buffSize));
     }
     const char* dataOr = origCorr.mCorrectionData[is];
-    size_t dataSize = origCorr.mGeo.getNumberOfSectors() * sectorDataSizeBytes;
     std::memcpy(data, dataOr, dataSize);
     nextDynOffs += dataSize;
   }
-
+  nextDynOffs = alignOffset(nextDynOffs);
   podMap.mTotalSize = nextDynOffs;
   if (buffSize != podMap.mTotalSize) {
     throw std::runtime_error(fmt::format("Estimated buffer size {} differs from filled one {}", buffSize, podMap.mTotalSize));

--- a/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
+++ b/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
@@ -210,6 +210,14 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root", const char*
 
   o2::gpu::TPCFastSpaceChargeCorrection& corr = fastTransform->getCorrection();
 
+  aligned_unique_buffer_ptr<TPCFastTransformPOD> podBuffer;
+  TPCFastTransformPOD* corrPODptr = TPCFastTransformPOD::create(podBuffer, *fastTransform);
+
+  if (!corrPODptr) {
+    throw std::runtime_error("Failed to create TPCFastTransformPOD");
+  }
+  const TPCFastTransformPOD& corrPOD = *corrPODptr;
+
   // a debug file with some NTuples
 
   TDirectory* currDir = gDirectory;
@@ -302,19 +310,35 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root", const char*
 
   const o2::gpu::TPCFastTransformGeo& geo = helper->getGeometry();
 
+  float maxPodDiff[6] = {0., 0., 0., 0., 0., 0.};
+
   auto getInvCorrections = [&](int iSector, int iRow, float realY, float realZ, float& ix, float& iy, float& iz) {
     // get the inverse corrections ix, iy, iz at x,y,z
     ix = corr.getCorrectionXatRealYZ(iSector, iRow, realY, realZ);
     corr.getCorrectionYZatRealYZ(iSector, iRow, realY, realZ, iy, iz);
+
+    float ixPod = corrPOD.getCorrectionXatRealYZ(iSector, iRow, realY, realZ);
+    float iyPod, izPod;
+    corrPOD.getCorrectionYZatRealYZ(iSector, iRow, realY, realZ, iyPod, izPod);
+
+    maxPodDiff[3] = std::max(maxPodDiff[3], fabs(ix - ixPod));
+    maxPodDiff[4] = std::max(maxPodDiff[4], fabs(iy - iyPod));
+    maxPodDiff[5] = std::max(maxPodDiff[5], fabs(iz - izPod));
   };
 
   auto getAllCorrections = [&](int iSector, int iRow, float y, float z, float& cx, float& cy, float& cz, float& ix, float& iy, float& iz) {
     // get the corrections cx,cy,cz at x,y,z
     corr.getCorrectionLocal(iSector, iRow, y, z, cx, cy, cz);
     getInvCorrections(iSector, iRow, y + cy, z + cz, ix, iy, iz);
+
+    float cxPod, cyPod, czPod;
+    corrPOD.getCorrectionLocal(iSector, iRow, y, z, cxPod, cyPod, czPod);
+    maxPodDiff[0] = std::max(maxPodDiff[0], fabs(cx - cxPod));
+    maxPodDiff[1] = std::max(maxPodDiff[1], fabs(cy - cyPod));
+    maxPodDiff[2] = std::max(maxPodDiff[2], fabs(cz - czPod));
   };
 
-  for (int direction = 0; direction < 2; direction++) { // 0 - normal, 1 - inverse
+  for (int direction = 0; direction < 2; direction++) { // 0 - direct, 1 - inverse
 
     std::string directionName = (direction == 0) ? "direct" : "inverse";
 
@@ -594,7 +618,9 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root", const char*
     for (int32_t i = 0; i < 3; i++) {
       sumDiff[i] = sqrt(sumDiff[i]) / nDiff;
     }
+
     LOG(info) << directionName << " correction: max and mean differences between spline and voxel corrections:";
+
     LOG(info) << "Max difference in x :  " << maxDiff[0] << " at Sector "
               << maxDiffSector[0] << " row " << maxDiffRow[0];
 
@@ -605,8 +631,21 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root", const char*
               << maxDiffSector[2] << " row " << maxDiffRow[2];
 
     LOG(info) << "Mean difference in x,y,z : " << sumDiff[0] << " " << sumDiff[1]
-              << " " << sumDiff[2] << std::endl;
+              << " " << sumDiff[2];
+
+    LOG(info) << std::endl;
+
   } // direction
+
+  LOG(info) << " max difference between POD and original corrections: ";
+  LOG(info) << " x " << maxPodDiff[0];
+  LOG(info) << " y " << maxPodDiff[1];
+  LOG(info) << " z " << maxPodDiff[2];
+  LOG(info) << " inverse x " << maxPodDiff[3];
+  LOG(info) << " inverse y " << maxPodDiff[4];
+  LOG(info) << " inverse z " << maxPodDiff[5];
+
+  LOG(info) << std::endl;
 
   corr.testInverse(true);
 


### PR DESCRIPTION
Hi David, Ruben.  

@davidrohr, @shahor02

This PR fixes the commit [bd7be4f9a69b37b50ee0fcd3c94b58a6b346d4cb](https://github.com/AliceO2Group/AliceO2/commit/cc36054b0fe1acbf080a7c57e67ffb8be4020e59)
"TPCFastTransform: reduce the metadata: the same spline setup for all the sectors"

The TPCFastSpaceChargeCorrection and the TPCFastTransformPOD now show the same results everywhere on the CPU. 
I didn't test it on the GPU, but it must work. David, please check.

There is a little difference (of the order of 1.e-6 at max) in getCorrectionYZatRealYZ(..) between the POD and the standard version of the SC correction.

I assume the difference is due to differences in the code optimization.

This difference was not there before. It appears right after the commit  [b90942c92ed3bc599e157472db21585069483325](https://github.com/AliceO2Group/AliceO2/commit/b90942c92ed3bc599e157472db21585069483325)
"TPCFastTransform: remove row-wise max correction values"

It disappears again when I disable the check for the large values in getCorrectionYZatRealYZ()  by commenting out the corresponding lines:

https://github.com/sgorbuno/AliceO2/blob/PR21.04/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.h#L500
https://github.com/sgorbuno/AliceO2/blob/PR21.04/GPU/TPCFastTransformation/TPCFastTransformPOD.h#L362

Interesting: in my test, the check for large values is never triggered. But just the presence of this check in the code changes the calculations, apparently. 
